### PR TITLE
Add chinese/japanese fonts support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:4.2
 
 RUN apt-get update && \
-    apt-get install -y xvfb iceweasel
+    apt-get install -y xvfb iceweasel fonts-takao fonts-wqy-zenhei
 
 RUN npm install -g slimerjs phantomjs manet@0.4.8
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Dockerfile for Manet - Website screenshot service powered by Node.js, SlimerJS a
 This is a Dockerfile for [vbauer/manet project](https://github.com/vbauer/manet).
 The associated docker image is hosted on [Docker Hub](https://hub.docker.com/r/bobey/manet).
 
+This container supports extended charactersets such as Japanese and Chinese.
+
 ## What is Manet?
 
 **Manet** is a REST API server which allows capturing screenshots of websites using various parameters.


### PR DESCRIPTION
Installing `fonts-takao` and `fonts-wqy-zenhei` adds support for japanese and chinese charactersets.
