### PR TITLE
Update to latest stable Node, Firefox ESR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:4.2
+FROM node:6
 
-RUN apt-get update && \
-    apt-get install -y xvfb iceweasel fonts-takao fonts-wqy-zenhei
+RUN echo 'deb http://mozilla.debian.net/ jessie-backports firefox-release' > /etc/apt/sources.list.d/debian-mozilla.list && \
+    wget https://mozilla.debian.net/pkg-mozilla-archive-keyring_1.1_all.deb && \
+    dpkg -i pkg-mozilla-archive-keyring_1.1_all.deb && \
+    apt-get update && \
+    apt-get install -y xvfb firefox fonts-takao fonts-wqy-zenhei
 
 RUN npm install -g slimerjs phantomjs manet@0.4.19
 


### PR DESCRIPTION
Two major changes: update from Node 4.2 -> 6.x, and from Iceweasel/Firefox 45.x to Firefox 52, the new ESR.